### PR TITLE
Implement the API for adding a new review

### DIFF
--- a/docs-core/src/main/java/com/sismics/docs/core/dao/ReviewDao.java
+++ b/docs-core/src/main/java/com/sismics/docs/core/dao/ReviewDao.java
@@ -1,0 +1,31 @@
+package com.sismics.docs.core.dao;
+
+import com.sismics.docs.core.model.jpa.Review;
+import com.sismics.util.context.ThreadLocalContext;
+
+import javax.persistence.EntityManager;
+import java.util.*;
+
+/**
+ * Review DAO.
+ *
+ * @author Nicolas Ettlin
+ */
+public class ReviewDao {
+    /**
+     * Creates a new review.
+     *
+     * @param review The review
+     * @return New ID
+     */
+    public String create(Review review) {
+        // Create the UUID
+        review.setId(UUID.randomUUID().toString());
+
+        // Create the review
+        EntityManager em = ThreadLocalContext.get().getEntityManager();
+        em.persist(review);
+
+        return review.getId();
+    }
+}

--- a/docs-core/src/main/java/com/sismics/docs/core/dao/ReviewDao.java
+++ b/docs-core/src/main/java/com/sismics/docs/core/dao/ReviewDao.java
@@ -1,7 +1,10 @@
 package com.sismics.docs.core.dao;
 
 import com.sismics.docs.core.model.jpa.Review;
+import com.sismics.docs.core.model.jpa.Route;
+import com.sismics.docs.core.model.jpa.RouteModel;
 import com.sismics.util.context.ThreadLocalContext;
+import org.apache.commons.lang.NotImplementedException;
 
 import javax.persistence.EntityManager;
 import java.util.*;
@@ -16,6 +19,7 @@ public class ReviewDao {
      * Creates a new review.
      *
      * @param review The review
+     *
      * @return New ID
      */
     public String create(Review review) {
@@ -27,5 +31,14 @@ public class ReviewDao {
         em.persist(review);
 
         return review.getId();
+    }
+
+    /**
+     * Returns the list of all route models.
+     *
+     * @return Map containing the reviews for each route on the document with a resume review step
+     */
+    public Map<Route, List<Review>> findByDocument(String documentId) {
+        throw new NotImplementedException();
     }
 }

--- a/docs-core/src/main/java/com/sismics/docs/core/dao/ReviewDao.java
+++ b/docs-core/src/main/java/com/sismics/docs/core/dao/ReviewDao.java
@@ -2,9 +2,7 @@ package com.sismics.docs.core.dao;
 
 import com.sismics.docs.core.model.jpa.Review;
 import com.sismics.docs.core.model.jpa.Route;
-import com.sismics.docs.core.model.jpa.RouteModel;
 import com.sismics.util.context.ThreadLocalContext;
-import org.apache.commons.lang.NotImplementedException;
 import org.apache.commons.lang3.tuple.Pair;
 
 import javax.persistence.EntityManager;

--- a/docs-core/src/main/java/com/sismics/docs/core/dao/ReviewDao.java
+++ b/docs-core/src/main/java/com/sismics/docs/core/dao/ReviewDao.java
@@ -5,8 +5,10 @@ import com.sismics.docs.core.model.jpa.Route;
 import com.sismics.docs.core.model.jpa.RouteModel;
 import com.sismics.util.context.ThreadLocalContext;
 import org.apache.commons.lang.NotImplementedException;
+import org.apache.commons.lang3.tuple.Pair;
 
 import javax.persistence.EntityManager;
+import javax.persistence.Query;
 import java.util.*;
 
 /**
@@ -38,7 +40,52 @@ public class ReviewDao {
      *
      * @return Map containing the reviews for each route on the document with a resume review step
      */
+    @SuppressWarnings("unchecked")
     public Map<Route, List<Review>> findByDocument(String documentId) {
-        throw new NotImplementedException();
+        EntityManager em = ThreadLocalContext.get().getEntityManager(); // NULL?
+        Query q = em.createNativeQuery("select\n" +
+                "    RTE_ID_C, RTE_IDDOCUMENT_C, RTE_NAME_C, RTE_CREATEDATE_D, RTE_DELETEDATE_D,\n" +
+                "    REV_ID_C, REV_IDROUTESTEP_C, REV_CATEGORY_C, REV_VALUE_DBL \n" +
+                "from T_ROUTE\n" +
+                "inner join T_ROUTE_STEP\n" +
+                "    on RTP_IDROUTE_C = RTE_ID_C\n" +
+                "    and RTP_TYPE_C = 'RESUME_REVIEW'\n" +
+                "    and RTP_DELETEDATE_D is null\n" +
+                "left join T_REVIEW on REV_IDROUTESTEP_C = RTP_ID_C\n" +
+                "where RTE_IDDOCUMENT_C = :documentId");
+        q.setParameter("documentId", documentId);
+
+        HashMap<String, Pair<Route, List<Review>>> byRouteId = new HashMap<>(); // route id → (route, reviews)
+        for (Object[] row : (List<Object[]>)q.getResultList()) {
+            int i = 0;
+
+            // Create the route object
+            String routeId = (String)row[i++];
+            if (!byRouteId.containsKey(routeId)) {
+                Route route = new Route();
+                route.setId(routeId);
+                route.setDocumentId((String)row[i++]);
+                route.setName((String)row[i++]);
+                route.setCreateDate((Date)row[i++]);
+                route.setDeleteDate((Date)row[i++]);
+
+                byRouteId.put(routeId, Pair.of(route, new LinkedList<>()));
+            }
+
+            // Create the review object
+            i = 5;
+            if (row[i] == null) continue; // workflow without reviews
+            Review review = new Review();
+            review.setId((String)row[i++]);
+            review.setRouteStepId((String)row[i++]);
+            review.setCategory((String)row[i++]);
+            review.setValue((Double)row[i++]);
+
+            byRouteId.get(routeId).getRight().add(review);
+        }
+
+        HashMap<Route, List<Review>> result = new HashMap<>();
+        byRouteId.forEach((routeId, pair) -> result.put(pair.getLeft(), pair.getRight()));
+        return result;
     }
 }

--- a/docs-core/src/main/java/com/sismics/docs/core/model/jpa/Review.java
+++ b/docs-core/src/main/java/com/sismics/docs/core/model/jpa/Review.java
@@ -16,6 +16,21 @@ import java.util.Date;
 @Table(name = "T_REVIEW")
 public class Review {
     /**
+     * The max length of a category name
+     */
+    public static final int CATEGORY_MAX_LENGTH = 36;
+
+    /**
+     * The minimum value for a rating
+     */
+    public static final double RATING_MIN = 1;
+
+    /**
+     * The maximum value for a rating
+     */
+    public static final double RATING_MAX = 5;
+
+    /**
      * The review’s unique identifier.
      */
     @Id
@@ -31,11 +46,11 @@ public class Review {
     /**
      * The name of the category this review refers to.
      */
-    @Column(name = "REV_CATEGORY_C", nullable = false, length = 36)
+    @Column(name = "REV_CATEGORY_C", nullable = false, length = CATEGORY_MAX_LENGTH)
     private String category;
 
     /**
-     * The value of this review (1–5).
+     * The value of this review (range: {@value #RATING_MIN} to {@value #RATING_MAX}).
      */
     @Column(name = "REV_VALUE_DBL", nullable = false)
     private double value;

--- a/docs-core/src/main/java/com/sismics/docs/core/model/jpa/Review.java
+++ b/docs-core/src/main/java/com/sismics/docs/core/model/jpa/Review.java
@@ -1,0 +1,84 @@
+package com.sismics.docs.core.model.jpa;
+
+import com.google.common.base.MoreObjects;
+import com.sismics.docs.core.constant.AclType;
+import com.sismics.docs.core.constant.PermType;
+
+import javax.persistence.*;
+import java.util.Date;
+
+/**
+ * Review entity.
+ * 
+ * @author Nicolas Ettlin
+ */
+@Entity
+@Table(name = "T_REVIEW")
+public class Review {
+    /**
+     * The review’s unique identifier.
+     */
+    @Id
+    @Column(name = "REV_ID_C", length = 36)
+    private String id;
+
+    /**
+     * The ID of the {@link RouteStep} this review belongs to.
+     */
+    @Column(name = "REV_IDROUTESTEP_C", nullable = false, length = 36)
+    private String routeStepId;
+
+    /**
+     * The name of the category this review refers to.
+     */
+    @Column(name = "REV_CATEGORY_C", nullable = false, length = 36)
+    private String category;
+
+    /**
+     * The value of this review (1–5).
+     */
+    @Column(name = "REV_VALUE_DBL", nullable = false)
+    private double value;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getRouteStepId() {
+        return routeStepId;
+    }
+
+    public void setRouteStepId(String routeStepId) {
+        this.routeStepId = routeStepId;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public void setCategory(String category) {
+        this.category = category;
+    }
+
+    public double getValue() {
+        return value;
+    }
+
+    public void setValue(double value) {
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("id", id)
+                .add("routeStepId", routeStepId)
+                .add("category", category)
+                .add("value", value)
+                .toString();
+    }
+}

--- a/docs-core/src/main/resources/config.properties
+++ b/docs-core/src/main/resources/config.properties
@@ -1,1 +1,1 @@
-db.version=27
+db.version=28

--- a/docs-core/src/main/resources/db/update/dbupdate-028-0.sql
+++ b/docs-core/src/main/resources/db/update/dbupdate-028-0.sql
@@ -1,4 +1,4 @@
-create memory table T_REVIEW ( REV_ID_C varchar(36) not null, REV_IDROUTESTEP_C varchar(36) not null, REV_CATEGORY_C varchar(36) not null, REV_VALUE_DEC decimal(3, 2) not null, primary key (REV_ID_C) );
+create memory table T_REVIEW ( REV_ID_C varchar(36) not null, REV_IDROUTESTEP_C varchar(36) not null, REV_CATEGORY_C varchar(36) not null, REV_VALUE_DBL double not null, primary key (REV_ID_C) );
 
 alter table T_REVIEW add constraint FK_REV_IDROUTESTEP_C foreign key (REV_IDROUTESTEP_C) references T_ROUTE_STEP (RTP_ID_C) on delete cascade on update cascade;
 

--- a/docs-core/src/main/resources/db/update/dbupdate-028-0.sql
+++ b/docs-core/src/main/resources/db/update/dbupdate-028-0.sql
@@ -1,0 +1,5 @@
+create memory table T_REVIEW ( REV_ID_C varchar(36) not null, REV_IDROUTESTEP_C varchar(36) not null, REV_CATEGORY_C varchar(36) not null, REV_VALUE_DEC decimal(3, 2) not null, primary key (REV_ID_C) );
+
+alter table T_REVIEW add constraint FK_REV_IDROUTESTEP_C foreign key (REV_IDROUTESTEP_C) references T_ROUTE_STEP (RTP_ID_C) on delete cascade on update cascade;
+
+update T_CONFIG set CFG_VALUE_C = '28' where CFG_ID_C = 'DB_VERSION';

--- a/docs-core/src/main/resources/db/update/dbupdate-028-0.sql
+++ b/docs-core/src/main/resources/db/update/dbupdate-028-0.sql
@@ -1,4 +1,4 @@
-create memory table T_REVIEW ( REV_ID_C varchar(36) not null, REV_IDROUTESTEP_C varchar(36) not null, REV_CATEGORY_C varchar(36) not null, REV_VALUE_DBL double not null, primary key (REV_ID_C) );
+create cached table T_REVIEW ( REV_ID_C varchar(36) not null, REV_IDROUTESTEP_C varchar(36) not null, REV_CATEGORY_C varchar(36) not null, REV_VALUE_DBL double not null, primary key (REV_ID_C) );
 
 alter table T_REVIEW add constraint FK_REV_IDROUTESTEP_C foreign key (REV_IDROUTESTEP_C) references T_ROUTE_STEP (RTP_ID_C) on delete cascade on update cascade;
 

--- a/docs-web/src/dev/resources/config.properties
+++ b/docs-web/src/dev/resources/config.properties
@@ -1,3 +1,3 @@
 api.current_version=${project.version}
 api.min_version=1.0
-db.version=27
+db.version=28

--- a/docs-web/src/main/java/com/sismics/docs/rest/resource/RouteResource.java
+++ b/docs-web/src/main/java/com/sismics/docs/rest/resource/RouteResource.java
@@ -141,6 +141,7 @@ public class RouteResource extends BaseResource {
      * @apiSuccess {String} status Status OK
      * @apiError (client) ForbiddenError Access denied
      * @apiError (client) NotFound Document or route not found
+     * @apiError (client) ValidationError The query parameters don’t match the expected format
      * @apiPermission user
      * @apiVersion 1.5.0
      *

--- a/docs-web/src/main/java/com/sismics/docs/rest/resource/RouteResource.java
+++ b/docs-web/src/main/java/com/sismics/docs/rest/resource/RouteResource.java
@@ -213,7 +213,7 @@ public class RouteResource extends BaseResource {
                     review.setValue(value);
                     reviews.add(review);
                 }
-            } catch (JsonException | ClassCastException e) {
+            } catch (JsonException | ClassCastException | NullPointerException e) {
                 throw new ClientException("ValidationError", "The ratings field doesn't contain valid JSON");
             }
         }

--- a/docs-web/src/prod/resources/config.properties
+++ b/docs-web/src/prod/resources/config.properties
@@ -1,3 +1,3 @@
 api.current_version=${project.version}
 api.min_version=1.0
-db.version=27
+db.version=28

--- a/docs-web/src/test/java/com/sismics/docs/rest/TestRouteResource.java
+++ b/docs-web/src/test/java/com/sismics/docs/rest/TestRouteResource.java
@@ -3,12 +3,15 @@ package com.sismics.docs.rest;
 import com.sismics.docs.core.dao.ReviewDao;
 import com.sismics.docs.core.model.jpa.Review;
 import com.sismics.docs.core.model.jpa.Route;
+import com.sismics.util.context.ThreadLocalContext;
 import com.sismics.util.filter.TokenBasedSecurityFilter;
+import com.sismics.util.jpa.EMF;
 import org.junit.Assert;
 import org.junit.Test;
 
 import javax.json.JsonArray;
 import javax.json.JsonObject;
+import javax.persistence.EntityManager;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Form;
 import javax.ws.rs.core.Response;
@@ -527,6 +530,12 @@ public class TestRouteResource extends BaseJerseyTest {
      */
     @Test
     public void testValidateRouteWithResumeReview() {
+        // Setup: Initialize the entity manager (needed so we can query the database from the test)
+        EntityManager em = EMF.get().createEntityManager();
+        ThreadLocalContext.get().setEntityManager(em);
+        em.getTransaction().begin();
+
+        // Setup: Get the access token
         token = clientUtil.login("admin", "admin", false);
 
         // Setup: create some workflows

--- a/docs-web/src/test/java/com/sismics/docs/rest/TestRouteResource.java
+++ b/docs-web/src/test/java/com/sismics/docs/rest/TestRouteResource.java
@@ -610,7 +610,7 @@ public class TestRouteResource extends BaseJerseyTest {
         // Test: the workflow with two reviews is there
         List<Review> secondWorkflowReviews = find(
                 results,
-                (route, reviews) -> route.getName().equals("No reviews workflow")
+                (route, reviews) -> route.getName().equals("Two reviews workflow")
         );
         Assert.assertNotNull(secondWorkflowReviews);
         Assert.assertEquals(10, secondWorkflowReviews.size());


### PR DESCRIPTION
This PR closes #5.

A couple remarks about the implementation:

* The reviews are stored in a new table `T_REVIEW`, whose fields are:
```sql
T_REVIEW (
    REV_ID_C varchar(36) not null,
    REV_IDROUTESTEP_C varchar(36) not null,
    REV_CATEGORY_C varchar(36) not null,
    REV_VALUE_DBL double not null,
);
```

* The new `ReviewDao` class provides methods to interact with the new `Review` Java type. Its `findByDocument` method will probably be very helpful for the implementation of #10.
