### PR TITLE
Resume workflow history

### DIFF
--- a/docs-web/src/main/webapp/src/partial/docs/document.view.workflow.html
+++ b/docs-web/src/main/webapp/src/partial/docs/document.view.workflow.html
@@ -52,12 +52,13 @@
   </thead>
   <tbody>
   <tr ng-repeat="step in route.steps" ng-class="{
-          'bg-success': step.transition == 'VALIDATED' || step.transition == 'APPROVED',
+          'bg-success': step.transition == 'VALIDATED' || step.transition == 'APPROVED' || step.transition == 'REVIEWED',
           'bg-danger': step.transition == 'REJECTED'
       }">
     <td>
       <span class="fas fa-exchange-alt" ng-if="step.type == 'APPROVE'"></span>
       <span class="fas fa-check-circle" ng-if="step.type == 'VALIDATE'"></span>
+      <span class="fas fa-file" ng-if="step.type == 'RESUME_REVIEW'"></span>
       {{ 'workflow_type.' + step.type | translate }}
     </td>
     <td>{{ step.name }}</td>
@@ -70,7 +71,7 @@
           {{ step.end_date | timeAgo: dateTimeFormat }}
           by
         <a href="#/user/{{ step.validator_username }}" class="label label-default">{{ step.validator_username }}</a>
-        <span ng-show="step.comment" class="text-">
+        <span ng-show="step.comment && step.transition != 'REVIEWED'" class="text-">
           <br/><em>{{ step.comment }}</em>
         </span>
       </span>

--- a/docs-web/src/main/webapp/src/partial/docs/settings.workflow.edit.html
+++ b/docs-web/src/main/webapp/src/partial/docs/settings.workflow.edit.html
@@ -48,7 +48,7 @@
                     <span class="input-group-addon">
                       <span class="fas fa-exchange-alt" ng-if="step.type == 'APPROVE'"></span>
                       <span class="fas fa-check-circle" ng-if="step.type == 'VALIDATE'"></span>
-                      <span class="far fa-file" ng-if="step.type == 'RESUME_REVIEW'"></span>
+                      <span class="fas fa-file" ng-if="step.type == 'RESUME_REVIEW'"></span>
                     </span>
                     <select class="form-control" name="type-{{ $index }}" ng-model="step.type" ng-change="updateTransitions(step)" required>
                       <option value="APPROVE">{{ 'settings.workflow.edit.type_approve' | translate }}</option>


### PR DESCRIPTION
Closes #8.

* Put the rows in green for validated resume review steps
* Add a resume review icon
* Hide comments for resume reviews